### PR TITLE
[박세민 / BOJ 골드4] 인구 이동

### DIFF
--- a/3주차/semin/BOJ_인구 이동.java
+++ b/3주차/semin/BOJ_인구 이동.java
@@ -1,0 +1,85 @@
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    static int N, L, R;
+    static int[][] map;
+    static boolean[][] visited;
+    static int[] dx = {-1, 1, 0, 0};
+    static int[] dy = {0, 0, -1, 1};
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br  = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        L = Integer.parseInt(st.nextToken());
+        R = Integer.parseInt(st.nextToken());
+
+        map = new int[N][N];
+        for(int i=0; i<N; i++){
+            st = new StringTokenizer(br.readLine());
+            for(int j=0; j<N; j++){
+                map[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        int days = 0;
+        while(true){
+            visited = new boolean[N][N];
+            boolean moved = false;
+
+            for(int i=0; i<N; i++){
+                for(int j=0; j<N; j++){
+                    if(!visited[i][j]){
+                        List<int[]> union = bfs(i, j);
+                        if(union.size() > 1){
+                            moved = true;
+                            int sum = 0;
+                            for(int[] pos : union){
+                                sum += map[pos[0]][pos[1]];
+                            }
+                            int avg = sum / union.size();
+                            for(int[] pos : union){
+                                map[pos[0]][pos[1]] = avg;
+                            }
+                        }
+                    }
+                }
+            }
+
+            if(!moved) break;
+            days++;
+        }
+
+        System.out.println(days);
+    }
+
+    static List<int[]> bfs(int x, int y){
+        Queue<int[]> q = new ArrayDeque<>();
+        List<int[]> union = new ArrayList<>();
+        q.add(new int[]{x, y});
+        union.add(new int[]{x, y});
+        visited[x][y] = true;
+
+        while(!q.isEmpty()){
+            int[] now = q.poll();
+            int cx = now[0];
+            int cy = now[1];
+
+            for(int i=0; i<4; i++){
+                int nx = cx + dx[i];
+                int ny = cy + dy[i];
+
+                if(nx >= 0 && ny >= 0 && nx < N && ny < N && !visited[nx][ny]){
+                    int diff = Math.abs(map[cx][cy] - map[nx][ny]);
+                    if(L <= diff && diff <= R){
+                        visited[nx][ny] = true;
+                        q.add(new int[]{nx, ny});
+                        union.add(new int[]{nx, ny});
+                    }
+                }
+            }
+        }
+        return union;
+    }
+}


### PR DESCRIPTION
## **🚀 접근 방식**

BFS로 인접 국가 간 인구 차이가 조건에 맞는지 확인하고 연합을 형성한다.

하루 동안 가능한 모든 연합을 만든 뒤 인구를 재분배한다.

이동이 일어났다면 하루를 증가시키고 반복한다.

## **⚡️ 시간/공간 복잡도**

- **시간복잡도:** O(N² × N²)
    
    → 매일 BFS를 최대 N²번, 각 BFS에서 최대 N² 순회
    
- **공간복잡도:** O(N²)
    
    → 지도, 방문 배열, 큐, 연합 리스트 등 사용
    

## **💭 느낀점**

BFS 탐색을 반복하는 구조지만 종료 조건을 정확히 확인하지 않으면 무한 루프가 발생할 수 있다.

방문 체크 배열을 매일 초기화해주는 것도 중요했다.

조건에 맞는 차이 계산을 정확히 구현해야 정답이 나온다.