### PR TITLE
[한재모 / BOJ 골드4] 인구 이동

### DIFF
--- a/3주차/jaemo/BOJ_인구 이동.java
+++ b/3주차/jaemo/BOJ_인구 이동.java
@@ -1,0 +1,111 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class Main {
+    static int N, L, R;
+    static int[] dRow = {1, 0, -1, 0};
+    static int[] dCol = {0, 1, 0, -1};
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        L = Integer.parseInt(st.nextToken());
+        R = Integer.parseInt(st.nextToken());
+        int[][] map = new int[N][N];
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < N; j++) {
+                map[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        int answer = 0;
+        while (true) {
+            boolean[][] visited = new boolean[N][N];
+            boolean isEnd = true;
+            for (int i = 0; i < N; i++) {
+                for (int j = 0; j < N; j++) {
+                    if (!visited[i][j]) {
+                        List<Point> unionPoints = open(map, visited, new Point(i, j, map[i][j]));
+                        if (unionPoints.size() > 1) {
+                            move(unionPoints, map);
+                            isEnd = false;
+                        }
+                    }
+                }
+            }
+
+            if (isEnd) {
+                break;
+            }
+
+            answer++;
+        }
+
+        System.out.println(answer);
+    }
+
+    // 국경선 open
+    public static List<Point> open(int[][] map, boolean[][] visited, Point startPoint) {
+        Queue<Point> queue = new LinkedList<>();
+        queue.add(startPoint);
+        visited[startPoint.r][startPoint.c] = true;
+
+        List<Point> unionPoints = new ArrayList<>();
+        unionPoints.add(startPoint);
+
+        while (!queue.isEmpty()) {
+            Point polled = queue.poll();
+            for (int d = 0; d < 4; d++) {
+                int nr = polled.r + dRow[d];
+                int nc = polled.c + dCol[d];
+                if (nr < 0 || nr >= N || nc < 0 || nc >= N) {
+                    continue;
+                }
+                int diff = Math.abs(map[nr][nc] - map[polled.r][polled.c]);
+                if (!visited[nr][nc] && (L <= diff && diff <= R)) {
+                    Point adjPoint = new Point(nr, nc, map[nr][nc]);
+                    queue.add(adjPoint);
+                    visited[nr][nc] = true;
+                    unionPoints.add(adjPoint);
+                }
+            }
+        }
+
+        return unionPoints;
+    }
+
+    // 인구 이동
+    public static void move(List<Point> unionPoints, int[][] map) {
+        if (unionPoints.isEmpty()) {
+            return;
+        }
+        int total = 0;
+        for (Point point : unionPoints) {
+            total += point.n;
+        }
+        int movedNumber = total / unionPoints.size();
+        for (Point point : unionPoints) {
+            map[point.r][point.c] = movedNumber;
+        }
+    }
+}
+
+class Point {
+    int r, c, n;
+
+    public Point(int r, int c, int n) {
+        this.r = r;
+        this.c = c;
+        this.n = n;
+    }
+}
+
+// if L <= 인접한 두 나라의 인구 차이 <= R -> 국경선 open
+// 모든 국경선이 열리면 이동 시작
+// 연합을 이루는 각 칸의 인구수 = 연합 인구수/연합을 이루는 칸 개수 (소수점 버림)
+
+// 인구 이동이 없을 때까지 며칠 걸림?


### PR DESCRIPTION
## 🚀 접근 방식
국경선을 여는 과정과 인구 이동 과정을 분리하여 각각 메서드로 구현했습니다.
국경선을 여는 메서드는 bfs를 사용하여 연합 지점들을 list로 반환하도록 했고, 인구 이동 메서드는 해당 list를 순회하며 2차원 배열 값을 수정하도록했습니다.

## ⚡️ 시간/공간 복잡도
- 시간: `O(T × N^2)`
- 공간: `O(N^2)`

## 💭 느낀점
조건이 친절해서, 각 순서에 따라 잘만 구현하면 어렵지 않은 문제인 것 같습니다.