### PR TITLE
[김희영 / BOJ 골드3] 내리막 길 

### DIFF
--- a/3주차/huiyeong/BOJ_내리막 길.java
+++ b/3주차/huiyeong/BOJ_내리막 길.java
@@ -1,0 +1,48 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class Main {
+    static int M, N;
+    static int[][] arr;
+    static int[][] dp;
+    static int[][] directions = {
+            {0, 1}, {1, 0}, {0, -1}, {-1, 0}
+    };
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        M = Integer.parseInt(st.nextToken());
+        N = Integer.parseInt(st.nextToken());
+
+        arr = new int[M][N];
+        dp = new int[M][N];
+        for (int i = 0; i < M; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < N; j++) {
+                arr[i][j] = Integer.parseInt(st.nextToken());
+                dp[i][j] = -1;
+            }
+        }
+
+        System.out.println(DFS(0, 0));
+    }
+
+    private static int DFS(int x, int y) {
+        if (x == M - 1 && y == N - 1) return 1;
+
+        if (dp[x][y] != -1) return dp[x][y];
+        dp[x][y] = 0;
+
+        for (int i = 0; i < 4; i++) {
+            int nx = x + directions[i][0];
+            int ny = y + directions[i][1];
+
+            if (nx >= 0 && ny >= 0 && nx < M && ny < N && arr[nx][ny] < arr[x][y]) {
+                dp[x][y] += DFS(nx, ny);
+            }
+        }
+        return dp[x][y];
+    }
+}


### PR DESCRIPTION
## 🚀 접근 방식
처음에는 DFS에 단순히 더 낮은 높이로만 이동하는 조건을 추가하면 될 것이라 생각했습니다.
그래서 DFS로 모든 경로를 탐색했지만, 중복 경로 계산이 많아져서 시간 초과가 발생했습니다.

문제를 다시 분석해보니, (x, y)에서 목표 지점까지 가는 경로 수는 항상 같기 때문에
한 번 계산한 결과는 저장해두고 재사용(DP) 해야 한다는 점을 깨달았습니다.

## ⚡️ 시간/공간 복잡도
- 시간 복잡도 : O(M * N)
각 칸마다 DFS가 최대 한 번 호출합니다.
(*) DFS만 사용했을 경우 시간 복잡도 : O(4^(M*N)) 
위 아래 양옆을 다 해야 하기 때문입니다.

- 공간 복잡도 : O(M * N)
이차원 배열을 사용하기 때문입니다.

## 💭 느낀점
경우의 수가 많을 수록 중복 계산을 줄여야한다는 걸 몸소 느낀 문제였습니다.
