### PR TITLE
[한재모 / BOJ 골드3] 내리막 길, [한재모 / 프로그래머스 Lv.2] 두 큐 합 같게 만들기

### DIFF
--- a/3주차/jaemo/BOJ_내리막 길.java
+++ b/3주차/jaemo/BOJ_내리막 길.java
@@ -1,0 +1,49 @@
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    static int ROW, COL;
+    static int[] dRow = {1, 0, -1, 0};
+    static int[] dCol = {0, 1, 0, -1};
+    static int[][] map, dp;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        ROW = Integer.parseInt(st.nextToken());
+        COL = Integer.parseInt(st.nextToken());
+
+        map = new int[ROW][COL];
+        dp = new int[ROW][COL]; // 메모이제이션 배열
+        for (int i = 0; i < ROW; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < COL; j++) {
+                map[i][j] = Integer.parseInt(st.nextToken());
+                dp[i][j] = -1; // 아직 방문 안 했다는 의미
+            }
+        }
+
+        System.out.println(dfs(0, 0));
+    }
+
+    public static int dfs(int r, int c) {
+        if (r == ROW - 1 && c == COL - 1) return 1;
+
+        if (dp[r][c] != -1) return dp[r][c]; // 이미 계산한 경우
+
+        dp[r][c] = 0; // 초기값
+
+        for (int d = 0; d < 4; d++) {
+            int nr = r + dRow[d];
+            int nc = c + dCol[d];
+
+            if (nr >= 0 && nr < ROW && nc >= 0 && nc < COL) {
+                if (map[r][c] > map[nr][nc]) { // 내리막
+                    dp[r][c] += dfs(nr, nc);
+                }
+            }
+        }
+
+        return dp[r][c];
+    }
+}

--- a/3주차/jaemo/PG_두 큐 합 같게 만들기.java
+++ b/3주차/jaemo/PG_두 큐 합 같게 만들기.java
@@ -1,0 +1,49 @@
+import java.util.*;
+
+class Solution {
+    public int solution(int[] queue1, int[] queue2) {
+        int answer = 0;
+        Queue<Integer> queueA = new LinkedList<>();
+        Queue<Integer> queueB = new LinkedList<>();
+        long sumA = 0;
+        long sumB = 0;
+        for (int i=0;i<queue1.length;i++) {
+            int nowA = queue1[i];
+            sumA += nowA;
+            queueA.add(nowA);
+            int nowB = queue2[i];
+            sumB += nowB;
+            queueB.add(nowB);
+        }
+        
+        if (sumA == sumB) {
+            return 0;
+        }
+        
+        int size = queue1.length + queue2.length + 1;
+        
+        while (answer <= size) {
+            if (sumA > sumB) {
+                int polled = queueA.poll();
+                sumA -= polled;
+                sumB += polled;
+                queueB.add(polled);
+            } else if (sumA < sumB) {
+                int polled = queueB.poll();
+                sumB -= polled;
+                sumA += polled;
+                queueA.add(polled);
+            }
+            
+            answer++;
+            
+            if (sumA == sumB) {
+                return answer;
+            }
+        }
+        
+        return -1;
+    }
+}
+
+// 각 큐의 합을 같게 만드는 최소 작업 횟수 구하기


### PR DESCRIPTION
# BOJ 내리막길
## 🚀 접근 방식
모든 가능한 경로를 탐색하는 완전탐색으로 풀었지만 DFS로는 중복 탐색이 많아져서 메모리 초과가 발생했습니다.
따라서 메모이제이션(DP) 을 활용해 최적화했습니다.

## ⚡️ 시간/공간 복잡도
- 시간: `O(N × M)`
- 공간: `O(N × M)`

## 💭 느낀점
완전탐색으로 풀어보고 시간이나 메모리 초과가 발생하면 어떤 부분을 최적화해야 하는지 조금은 알 수 있었습니다.

---

# PG 두 큐 합 같게 만들기
## 🚀 접근 방식
단순히 두 큐에서 poll과 add 작업을 반복하는 방식으로 풀었습니다.
단, 각 큐의 합이 같아지는 경우의 수는 최대 2N이기 때문에 두 큐의 합 + 1번까지만 수행하도록 했습니다.

## ⚡️ 시간/공간 복잡도
- 시간: `O(N)`
- 공간: `O(N)`

## 💭 느낀점
최대 반복 횟수만 파악할 수 있다면 어렵지 않은 문제인 듯 합니다.