### PR TITLE
[박세민 / 프로그래머스 Lv.2] 메뉴 리뉴얼

### DIFF
--- a/4주차/semin/Programmers_메뉴 리뉴얼.java
+++ b/4주차/semin/Programmers_메뉴 리뉴얼.java
@@ -1,0 +1,59 @@
+import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+
+
+class Solution {
+    static HashMap<String, Integer> map = new HashMap<>();
+    static ArrayList<String> results = new ArrayList<>();
+    
+    public String[] solution(String[] orders, int[] course) {
+        String[] answer = {};
+
+        for (int i : course) {
+            for (String order : orders) {
+                char[] arr = order.toCharArray();
+                Arrays.sort(arr);
+
+                dfs(0,i,"",arr);
+            }
+
+            if (!map.isEmpty()) {
+                int max = Collections.max(map.values().stream().toList());
+                if (max > 1) {
+                    for (String key : map.keySet()) {
+                        if (map.get(key)==max) {
+                        	results.add(key);
+                        }
+                    }
+                }
+            }
+            map.clear();
+        }
+
+        Collections.sort(results);
+        answer = new String[results.size()];
+
+        for (int i = 0; i < answer.length; i++) {
+            answer[i] = results.get(i);
+        }
+
+        return answer;
+    }
+    static void dfs(int depth, int i, String course, char[] chars) {
+        if (course.length() == i) {
+            if (map.containsKey(course)) {
+            	map.put(course, map.get(course)+1);
+            }else{
+            	map.put(course, 1);
+            }
+            return;
+        }
+
+        if (depth < chars.length) {
+        	dfs(depth + 1, i, course + chars[depth], chars);
+            dfs(depth + 1, i, course, chars);
+        }
+    }
+}


### PR DESCRIPTION
### 🚀 접근 방식
각 주문을 정렬한 뒤, DFS를 통해 가능한 조합을 모두 생성하고, 해시맵을 활용해 빈도를 계산했다.
코스 길이별로 가장 많은 조합을 찾아 결과 리스트에 추가하였다.

### ⚡️ 시간/공간 복잡도
시간복잡도: O(N × 2^M)
→ 주문 N개에 대해 길이 M의 조합을 DFS로 탐색.
공간복잡도: O(K)
→ 조합 결과를 저장하는 해시맵과 결과 리스트 사용.

### 💭 느낀점
DFS , 해시맵, 백트래킹을 활용해보는 좋은 기회였다.