### PR TITLE
[박세민 / BOJ 골드2] 색종이 붙이기

### DIFF
--- a/5주차/semin/BOJ_색종이 붙이기.java
+++ b/5주차/semin/BOJ_색종이 붙이기.java
@@ -1,0 +1,68 @@
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+    static int minCount = 100;
+    static int[][] board = new int[10][10];
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        int paperCount = 0;
+        for (int i = 0; i < 10; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < 10; j++) {
+                board[i][j] = Integer.parseInt(st.nextToken());
+                if (board[i][j] == 1) paperCount++;
+            }
+        }
+
+        dfs(0, 0, 0, new int[]{0, 5, 5, 5, 5, 5}, paperCount);
+        System.out.println((minCount == 100) ? -1 : minCount);
+    }
+
+    static void dfs(int usedCount, int row, int col, int[] papersLeft, int remaining) {
+        if (remaining == 0) {
+            minCount = Math.min(minCount, usedCount);
+            return;
+        }
+
+        if (row >= 10) return;
+
+        if (board[row][col] == 0) {
+            if (col < 9) dfs(usedCount, row, col + 1, papersLeft, remaining);
+            else dfs(usedCount, row + 1, 0, papersLeft, remaining);
+            return;
+        }
+
+        for (int size = 1; size <= 5; size++) {
+            if (row + size > 10 || col + size > 10 || !canPlacePaper(row, col, size)) break;
+            if (papersLeft[size] > 0) {
+                placePaper(row, col, size);
+                papersLeft[size]--;
+                if (col < 9) dfs(usedCount + 1, row, col + 1, papersLeft, remaining - size * size);
+                else dfs(usedCount + 1, row + 1, 0, papersLeft, remaining - size * size);
+                placePaper(row, col, size);
+                papersLeft[size]++;
+            }
+        }
+    }
+
+    static boolean canPlacePaper(int row, int col, int size) {
+        for (int i = row; i < row + size; i++) {
+            for (int j = col; j < col + size; j++) {
+                if (board[i][j] != 1) return false;
+            }
+        }
+        return true;
+    }
+
+    static void placePaper(int row, int col, int size) {
+        for (int i = row; i < row + size; i++) {
+            for (int j = col; j < col + size; j++) {
+                board[i][j] ^= 1; // 1이면 0으로, 0이면 1로 뒤집는 토글
+            }
+        }
+    }
+}


### PR DESCRIPTION
### 🚀 접근 방식
DFS로 모든 좌표를 순회하면서 1을 덮기 위해 가능한 색종이 크기를 탐색했다.
색종이를 붙였다가 떼며 백트래킹을 수행했다.

### ⚡️ 시간/공간 복잡도
시간복잡도: O(5^25) (최악의 경우 모든 경우의 수 탐색)
→ 완전탐색이지만 백트래킹과 조건 분기로 가지치기 수행.
공간복잡도: O(1)
→ 고정된 10×10 보드만 사용한다.

### 💭 느낀점
색종이 크기별 개수 '제한'을 활용해 효율적으로 가지치기를 수행해야 했다.