### PR TITLE
[김지희/ BOJ 골드 4] 트리의 지름, [김지희/ BOJ 골드 4] 빙산

### DIFF
--- a/8주차/jihee/BOJ_빙산.java
+++ b/8주차/jihee/BOJ_빙산.java
@@ -1,0 +1,126 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class Main {
+
+    static class node {
+        int x;
+        int y;
+
+        node(int x, int y) {
+            this.x = x;
+            this.y = y;
+        }
+    }
+
+    static int N, M;
+    static int[][] map;
+    static boolean[][] visited;
+    static int[] dx = {-1, 0, 0, 1};
+    static int[] dy = {0, -1, 1, 0};
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer stringTokenizer = new StringTokenizer(br.readLine());
+
+        N = Integer.parseInt(stringTokenizer.nextToken());
+        M = Integer.parseInt(stringTokenizer.nextToken());
+
+        map = new int[N][M];
+        for (int i = 0; i < N; i++) {
+            stringTokenizer = new StringTokenizer(br.readLine());
+            for (int j = 0; j < M; j++) {
+                map[i][j] = Integer.parseInt(stringTokenizer.nextToken());
+            }
+        }
+
+        int year = 0;
+
+        while (true) {
+            visited = new boolean[N][M];
+            int cnt = 0;
+            boolean flag = false;
+
+            for (int i = 0; i < N; i++) {
+                for (int j = 0; j < M; j++) {
+                    if (map[i][j] != 0 && !visited[i][j]) {
+                        cnt++;
+                        if (cnt == 2) {
+                            flag = true;
+                            break;
+                        }
+                        bfs(i, j);
+                    }
+                }
+            }
+            if (flag)
+                break;
+
+            if (cnt == 0) {
+                year = 0;
+                break;
+            }
+
+            dfs();
+            year++;
+        }
+
+        System.out.println(year);
+    }
+
+    private static void dfs() {
+        int[][] copyMap = new int[N][M];
+        for (int i = 0; i < N; i++) {
+            copyMap[i] = Arrays.copyOf(map[i], M);
+        }
+
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < M; j++) {
+                if (copyMap[i][j] != 0) {
+                    int zeroCnt = 0;
+
+                    for (int d = 0; d < 4; d++) {
+                        int nx = i + dx[d];
+                        int ny = j + dy[d];
+
+                        if (nx < 0 || N <= nx || ny < 0 || M <= ny)
+                            continue;
+
+                        if (copyMap[nx][ny] == 0)
+                            zeroCnt++;
+                    }
+
+                    map[i][j] = Math.max(0, copyMap[i][j] - zeroCnt);
+                }
+            }
+        }
+    }
+
+    private static void bfs(int x, int y) {
+        Queue<node> que = new LinkedList<>();
+        visited[x][y] = true;
+        que.offer(new node(x, y));
+
+        while (!que.isEmpty()) {
+            node now = que.poll();
+
+            for (int i = 0; i < 4; i++) {
+                int nx = now.x + dx[i];
+                int ny = now.y + dy[i];
+
+                if (nx < 0 || N <= nx || ny < 0 || M <= ny)
+                    continue;
+
+                if (map[nx][ny] != 0 && !visited[nx][ny]) {
+                    que.offer(new node(nx, ny));
+                    visited[nx][ny] = true;
+                }
+            }
+        }
+    }
+}

--- a/8주차/jihee/BOJ_트리의 지름.java
+++ b/8주차/jihee/BOJ_트리의 지름.java
@@ -1,0 +1,68 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.StringTokenizer;
+
+public class Main {
+
+    static boolean[] visited;
+    static ArrayList<Node>[] list;
+    static int max = 0;
+    static int num = 0;
+
+    static class Node {
+        int to;
+        int weight;
+
+        Node(int to, int weight) {
+            this.to = to;
+            this.weight = weight;
+        }
+    }
+
+    public static void dfs(int cur, int total) {
+        visited[cur] = true;
+        if (total > max) {
+            max = total;
+            num = cur;
+        }
+
+        for (Node next : list[cur]) {
+            if (!visited[next.to]) {
+                dfs(next.to, total + next.weight);
+            }
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int V = Integer.parseInt(br.readLine());
+        list = new ArrayList[V + 1];
+
+        for (int i = 1; i <= V; i++) {
+            list[i] = new ArrayList<>();
+        }
+
+        for (int i = 0; i < V; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            int tmp = Integer.parseInt(st.nextToken());
+            while (true) {
+                int to = Integer.parseInt(st.nextToken());
+                if (to == -1) break;
+                int weight = Integer.parseInt(st.nextToken());
+                list[tmp].add(new Node(to, weight));
+            }
+        }
+
+        visited = new boolean[V + 1];
+        dfs(1, 0);
+
+        visited = new boolean[V + 1];
+        max = 0;
+        dfs(num, 0);
+
+        System.out.println(max);
+    }
+
+}


### PR DESCRIPTION
# 트리의 지름
## 🚀 접근 방식
임의의 노드에서 가장 멀리 있는 노드를 찾고, 그 노드에서 다시 가장 멀리 떨어진 노드까지의 거리가 트리의 지름이 된다.
두 번의 DFS를 실행
첫 번째 DFS: 임의의 노드에서 가장 멀리 있는 노드를 찾음
두 번째 DFS: 그 노드에서 가장 멀리 있는 노드까지의 거리 계산 → 트리의 지름

## ⚡️ 시간/공간 복잡도
시간복잡도: O(V) 
공간복잡도: O(V) 

## 💭 느낀점
방문 배열을 재사용할 수 없기 때문에 DFS마다 초기화해야 한다.

# 빙산
## 🚀 접근 방식
각 해마다 빙산은 인접한 바닷물의 수만큼 높이가 줄어든다.
빙산이 2개 이상으로 분리되는 최초의 해를 출력한다.

## ⚡️ 시간/공간 복잡도
시간복잡도: O(NM)
공간복잡도: O(NM)

## 💭 느낀점
전형적인 bfs문제라 어렵지 않게 풀 수 있었다.