### PR TITLE
[박세민 / BOJ 실버 1] 나이트의 이동

### DIFF
--- a/10주차/semin/BOJ_나이트의 이동.java
+++ b/10주차/semin/BOJ_나이트의 이동.java
@@ -1,0 +1,48 @@
+import java.util.*;
+import java.io.*;
+
+public class Main {
+    public static void main(String[] args) throws IOException{
+    	int[] dx = {-2,-2,-1,-1,1,1,2,2};
+    	int[] dy = {1,-1,2,-2,2,-2,1,-1};
+    	
+    	BufferedReader br  = new BufferedReader(new InputStreamReader(System.in));
+    	StringTokenizer st;
+    	StringBuilder sb = new StringBuilder();
+    	int t = Integer.parseInt(br.readLine());
+    	while(t-->0) {
+    		int I = Integer.parseInt(br.readLine());
+    		int dist[][] = new int[I][I];
+    		for(int i=0;i<I;i++) {
+    			Arrays.fill(dist[i], -1);
+    		}
+    		
+    		st = new StringTokenizer(br.readLine());
+    		int start_x = Integer.parseInt(st.nextToken());
+    		int start_y = Integer.parseInt(st.nextToken());
+    		Queue<int[]> queue = new ArrayDeque<>();
+    		queue.add(new int[] {start_x, start_y});
+    		dist[start_x][start_y] = 0;
+    		
+    		st = new StringTokenizer(br.readLine());
+    		int finish_x = Integer.parseInt(st.nextToken());
+    		int finish_y = Integer.parseInt(st.nextToken());
+    		
+    		while(dist[finish_x][finish_y] == -1) {
+    			int[] cur = queue.poll();
+    			for(int i=0;i<8;i++) {
+    				int nx = cur[0]+dx[i];
+    				int ny = cur[1]+dy[i];
+    				if(0<=nx && nx<I
+    						&&0<=ny && ny<I
+    						&& dist[nx][ny] == -1) {
+    					dist[nx][ny] = dist[cur[0]][cur[1]] + 1;
+    					queue.add(new int[] {nx,ny});
+    				}
+    			}
+    		}
+    		sb.append(dist[finish_x][finish_y]+"\n");
+    	}
+    	System.out.print(sb);
+    }
+}


### PR DESCRIPTION
## 🚀 접근 방식
나이트의 이동은 8방향으로 제한되므로 BFS를 통해 최단 경로를 탐색한다.
방문 여부와 이동 횟수를 담는 dist 배열을 사용해 중복 방문을 방지한다.
시작점에서 목표 지점까지 도달하면 해당 좌표의 값을 출력한다.

## ⚡ 시간/공간 복잡도
- 시간 복잡도: O(N^2) 
 -> 체스판 전체를 탐색하는 BFS
- 공간 복잡도: O(N^2) 
 -> 거리 저장을 위한 2차원 배열 및 큐

## 💭 느낀점
BFS는 가중치가 동일한 그래프에서 최단 경로를 구할 때 매우 유용하다.