### PR TITLE
[박세민 / BOJ 실버 3] 2×n 타일링

### DIFF
--- a/10주차/semin/BOJ_2×n 타일링.java
+++ b/10주차/semin/BOJ_2×n 타일링.java
@@ -1,0 +1,21 @@
+import java.io.*;
+
+public class Main {
+
+	public static void main(String[] args) throws IOException{
+		BufferedReader br  = new BufferedReader(new InputStreamReader(System.in));
+		int n = Integer.parseInt(br.readLine());
+		if(n == 1 || n == 2) {
+			System.out.println(n);
+			return;
+		}
+		int[] dp = new int[n+1];
+		dp[1] = 1;
+		dp[2] = 2;
+		for(int i=3; i<n+1; i++) {
+			dp[i] = (dp[i-1] + dp[i-2])%10007;
+		}
+		System.out.println(dp[n]);
+	}
+
+}


### PR DESCRIPTION
## 🚀 접근 방식
2×n 크기의 직사각형을 채우는 경우의 수를 점화식 dp[n] = dp[n-1] + dp[n-2]로 계산한다.

## ⚡ 시간/공간 복잡도
- 시간 복잡도: O(n)
- 공간 복잡도: O(n)

## 💭 느낀점
