### PR TITLE
[박세민 / BOJ 실버 1] 오르막 수

### DIFF
--- a/10주차/semin/BOJ_오르막 수.java
+++ b/10주차/semin/BOJ_오르막 수.java
@@ -1,0 +1,32 @@
+import java.io.*;
+
+public class Main {
+
+	public static void main(String[] args) throws IOException{
+		BufferedReader br  = new BufferedReader(new InputStreamReader(System.in));
+		int N = Integer.parseInt(br.readLine());
+		
+		if(N==1) {
+			System.out.println(10);
+			return;
+		}
+		int[][] dp = new int[10][N];
+		for(int i=0; i<10; i++) {
+			dp[i][0] = 1;
+		}
+		
+		for(int i=1; i<N; i++) {
+			for(int j=0; j<10; j++) {
+				for(int k=0; k<j+1; k++) {
+					dp[j][i] = (dp[j][i] + dp[k][i-1]) % 10007;
+				}
+			}
+		}
+		
+		int output = dp[0][N-1];
+		for(int i=1; i<10; i++) {
+			output = (output + dp[i][N-1]) % 10007; 
+		}
+		System.out.println(output);
+	}
+}


### PR DESCRIPTION
## 🚀 접근 방식
dp[i][j]를 길이가 j+1이고 마지막 자릿수가 i인 오르막 수의 개수로 정의한다.
각 자릿수는 이전 자릿수의 0부터 i까지의 합으로 구성되므로 3중 반복문으로 누적한다.
최종적으로 길이가 N인 모든 오르막 수의 개수를 구해 출력한다.

## ⚡ 시간/공간 복잡도
- 시간 복잡도: O(N × 10 × 10)
- 공간 복잡도: O(N × 10)

## 💭 느낀점
