### PR TITLE
[김지희/ 프로그래머스 Lv.3] 표 편집

### DIFF
--- a/13주차/jihee/PG_표편집.java
+++ b/13주차/jihee/PG_표편집.java
@@ -1,0 +1,66 @@
+import java.util.*;
+
+class Solution {
+    public class Node {
+        int pre, cur, nxt;
+
+        public Node(int pre, int cur, int nxt) {
+            this.pre = pre;
+            this.cur = cur;
+            this.nxt = nxt;
+        }
+    }
+
+    public String solution(int n, int k, String[] cmd) {
+        String answer = "";
+        int[] pre = new int[n];
+        int[] next = new int[n];
+
+        for (int i = 0; i < n; ++i) {
+            pre[i] = i - 1;
+            next[i] = i + 1;
+        }
+
+        next[n - 1] = -1;
+
+        Deque<Node> dq = new ArrayDeque<>();
+        StringBuilder sb = new StringBuilder("O".repeat(n));
+
+        for (int i = 0; i < cmd.length; ++i) {
+            char type = cmd[i].charAt(0);
+
+            if (type == 'U') {
+                int num = Integer.parseInt(cmd[i].substring(2));
+                while (num-- > 0) {
+                    k = pre[k];
+                }
+            } else if (type == 'D') {
+                int num = Integer.parseInt(cmd[i].substring(2));
+
+                while (num-- > 0) {
+                    k = next[k];
+                }
+            } else if (type == 'C') {
+                dq.addFirst(new Node(pre[k], k, next[k]));
+                if (pre[k] != -1) next[pre[k]] = next[k];
+
+                if (next[k] != -1) pre[next[k]] = pre[k];
+
+                sb.setCharAt(k, 'X');
+
+                if (next[k] != -1) k = next[k];
+                else k = pre[k];
+
+            } else {
+                Node node = dq.removeFirst();
+
+                if (node.pre != -1) next[node.pre] = node.cur;
+                if (node.nxt != -1) pre[node.nxt] = node.cur;
+
+                sb.setCharAt(node.cur, 'O');
+            }
+        }
+
+        return answer = sb.toString();
+    }
+}


### PR DESCRIPTION
## 🚀 접근 방식
pre[], next[] 배열로 이중 연결 리스트를 구현해 각 행의  인덱스를 관리
삭제 시에는 현재 커서 위치의 이전/다음 노드를 연결하고, 삭제된 노드는 Deque에 저장하여 나중에 복구가 가능하도록 합니다.

## ⚡️ 시간/공간 복잡도
- 시간복잡도 : O(M)
- 공간복잡도 : O(N)

## 💭 느낀점
처음엔 LinkedList를 사용해서 시간 초과가 발생했다. 배열로 풀이를 바꾼 후 시간 복잡도가 줄어 해결할 수 있었다.