### PR TITLE
[박세민 / BOJ 골드 4] 트리의 지름

### DIFF
--- a/16주차/semin/BOJ_트리의 지름.java
+++ b/16주차/semin/BOJ_트리의 지름.java
@@ -1,0 +1,52 @@
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    static final int MXN = 100_010;
+    static boolean[] visited = new boolean[MXN];
+    static int maxCost = 0;
+    static int maxNode = 0;
+    static List<List<int[]>> adj = new ArrayList<>();
+
+    public static void dfs(int current, int dist) {
+        if (maxCost < dist) {
+            maxCost = dist;
+            maxNode = current;
+        }
+
+        for (int[] next : adj.get(current)) {
+            int nextDist = next[0];
+            int nextNode = next[1];
+            if (visited[nextNode]) continue;
+            visited[nextNode] = true;
+            dfs(nextNode, dist + nextDist);
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int n = Integer.parseInt(br.readLine());
+
+        for (int i = 0; i <= n; i++) {
+            adj.add(new ArrayList<>());
+        }
+
+        for (int i = 0; i < n - 1; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            int u = Integer.parseInt(st.nextToken());
+            int v = Integer.parseInt(st.nextToken());
+            int c = Integer.parseInt(st.nextToken());
+            adj.get(u).add(new int[]{c, v});
+            adj.get(v).add(new int[]{c, u});
+        }
+
+        visited[1] = true;
+        dfs(1, 0);
+
+        Arrays.fill(visited, false);
+        visited[maxNode] = true;
+        dfs(maxNode, 0);
+
+        System.out.println(maxCost);
+    }
+}


### PR DESCRIPTION
## 🚀 접근 방식
아무 노드에서 DFS를 통해 가장 먼 노드를 찾고, 해당 노드에서 다시 DFS하여 트리의 지름을 구했다.
인접 리스트로 트리를 구성하고, 방문 배열을 통해 중복 방문을 방지했다.
2번의 DFS로 트리의 최장 경로를 구하는 전형적인 방식이다.

## ⚡️ 시간/공간 복잡도
- 시간복잡도: O(N)
- 공간복잡도: O(N)

## 💭 느낀점
전형적인 문제 유형으로 DFS의 동작 원리를 복습하기에 좋았다.